### PR TITLE
Part 5: Lifecycle Hooks and Reactivation

### DIFF
--- a/code/08-lifecycle-hooks.js
+++ b/code/08-lifecycle-hooks.js
@@ -63,28 +63,11 @@ const beforePolicyReactivated = ({
 
   const newModule = {
     ...policy.module,
-    reactivation_date: '2024-01-01', //policy.start_date,
+    reactivation_date: '2024-03-01', //policy.start_date,
   };
 
   return [
     {
-      name: 'update_policy',
-      data: {
-        module: newModule,
-      },
-    },
-  ];
-};
-
-const setReactivationDate = ({ policy, reactivation_date }) => {
-  const newModule = {
-    ...policy.module,
-    start_date: reactivation_date,
-  };
-
-  return [
-    {
-      // name: 'activate_policy',
       name: 'update_policy',
       data: {
         module: newModule,

--- a/code/08-lifecycle-hooks.js
+++ b/code/08-lifecycle-hooks.js
@@ -48,22 +48,9 @@ const beforePolicyReactivated = ({
     );
   }
 
-  // Check policy was active within the last six months
-  const sixMonthsFromUpdated = moment(policy.status_updated_at).add(
-    6,
-    'months',
-  );
-  if (isPolicyLapsedOrCancelled && moment().isAfter(sixMonthsFromUpdated)) {
-    throw new Error(
-      `Policy can only be reactivated within 6 months of lapse or cancellation. Latest reactivation date was ${sixMonthsFromUpdated.format(
-        'YYYY-MM-DD',
-      )}`,
-    );
-  }
-
   const newModule = {
     ...policy.module,
-    reactivation_date: '2024-03-01', //policy.start_date,
+    reactivation_date: moment().format('YYYY-MM-DD'),
   };
 
   return [

--- a/code/08-lifecycle-hooks.js
+++ b/code/08-lifecycle-hooks.js
@@ -63,12 +63,11 @@ const beforePolicyReactivated = ({
 
   const newModule = {
     ...policy.module,
-    start_date: policy.start_date,
+    reactivation_date: '2024-01-01', //policy.start_date,
   };
 
   return [
     {
-      // name: 'activate_policy',
       name: 'update_policy',
       data: {
         module: newModule,

--- a/code/08-lifecycle-hooks.js
+++ b/code/08-lifecycle-hooks.js
@@ -60,7 +60,21 @@ const beforePolicyReactivated = ({
       )}`,
     );
   }
-  setReactivationDate({ policy, reactivation_date: moment() });
+
+  const newModule = {
+    ...policy.module,
+    start_date: policy.start_date,
+  };
+
+  return [
+    {
+      // name: 'activate_policy',
+      name: 'update_policy',
+      data: {
+        module: newModule,
+      },
+    },
+  ];
 };
 
 const setReactivationDate = ({ policy, reactivation_date }) => {
@@ -69,7 +83,6 @@ const setReactivationDate = ({ policy, reactivation_date }) => {
     start_date: reactivation_date,
   };
 
-  console.log('newModule', newModule);
   return [
     {
       // name: 'activate_policy',

--- a/code/08-lifecycle-hooks.js
+++ b/code/08-lifecycle-hooks.js
@@ -6,15 +6,7 @@
  * @return {ReactivationOption[]} One of these options must be selected whenever an inactive policy is reactivated.
  */
 const getReactivationOptions = (policy) => {
-  const settlementAmount = policy.balance < 0 ? -policy.balance : 0;
   return [
-    new ReactivationOption({
-      type: 'reinstatement',
-      settlementAmount,
-      description:
-        'For a policy to be reinstated, all arrear premiums will immediately be due.',
-      minimumBalanceRequired: true,
-    }),
     new ReactivationOption({
       type: 'recommencement',
       description:

--- a/code/08-lifecycle-hooks.js
+++ b/code/08-lifecycle-hooks.js
@@ -1,1 +1,82 @@
 // 08-lifecycle-hooks
+
+/**
+ * Get the reactivation options for inactive policies.
+ * @param {PlatformPolicy} policy The policy to be reactivated.
+ * @return {ReactivationOption[]} One of these options must be selected whenever an inactive policy is reactivated.
+ */
+const getReactivationOptions = (policy) => {
+  const settlementAmount = policy.balance < 0 ? -policy.balance : 0;
+  return [
+    new ReactivationOption({
+      type: 'reinstatement',
+      settlementAmount,
+      description:
+        'For a policy to be reinstated, all arrear premiums will immediately be due.',
+      minimumBalanceRequired: true,
+    }),
+    new ReactivationOption({
+      type: 'recommencement',
+      description:
+        'For a policy to be recommenced, all arrear premiums will be deducted from the first claim income.',
+      minimumBalanceRequired: false,
+    }),
+  ];
+};
+
+/**
+ * Executed before a policy is reactivated.
+ * Can be used to prevent reactivation if certain conditions are not met.
+ * @param {object} params
+ * @param {PlatformPolicy} params.policy The policy to be reactivated
+ * @param {PlatformPolicyholder} params.policyholder The policyholder linked to the policy
+ * @param {ReactivationOption} params.reactivationOption The reactivation option selected
+ * @return {ProductModuleAction[] | void} The actions to be queued by the platform
+ */
+const beforePolicyReactivated = ({
+  policy,
+  policyholder,
+  reactivationOption,
+}) => {
+  // Check policy status is lapsed or cancelled
+  const isPolicyLapsedOrCancelled = ['lapsed', 'cancelled'].includes(
+    policy.status,
+  );
+  if (!isPolicyLapsedOrCancelled) {
+    throw new Error(
+      `Policy with status ${policy.status} cannot be reactivated. Policy status must be one of ['lapsed', 'cancelled'].`,
+    );
+  }
+
+  // Check policy was active within the last six months
+  const sixMonthsFromUpdated = moment(policy.status_updated_at).add(
+    6,
+    'months',
+  );
+  if (isPolicyLapsedOrCancelled && moment().isAfter(sixMonthsFromUpdated)) {
+    throw new Error(
+      `Policy can only be reactivated within 6 months of lapse or cancellation. Latest reactivation date was ${sixMonthsFromUpdated.format(
+        'YYYY-MM-DD',
+      )}`,
+    );
+  }
+  setReactivationDate({ policy, reactivation_date: moment() });
+};
+
+const setReactivationDate = ({ policy, reactivation_date }) => {
+  const newModule = {
+    ...policy.module,
+    start_date: reactivation_date,
+  };
+
+  console.log('newModule', newModule);
+  return [
+    {
+      // name: 'activate_policy',
+      name: 'update_policy',
+      data: {
+        module: newModule,
+      },
+    },
+  ];
+};

--- a/code/unit-tests/04-lifecycle-hooks.tests.js
+++ b/code/unit-tests/04-lifecycle-hooks.tests.js
@@ -1,0 +1,106 @@
+const policy_active = {
+  policy_number: generatePolicyNumber(),
+  package_name: 'DinoSure Protection', // The name of the "package" of cover
+  sum_assured: 7500000,
+  base_premium: 10000,
+  monthly_premium: 205200,
+  start_date: moment().add(1, 'day').format(), // policy starts the day after issue
+  end_date: null,
+};
+const policy_lapsed = {
+  ...policy_active,
+  status: 'lapsed',
+};
+const policy_cancelled = {
+  ...policy_active,
+  status: 'cancelled',
+};
+const policy_expired = {
+  ...policy_active,
+  status: 'expired',
+};
+
+describe('Reactivation flow', () => {
+  // Setup
+  let reactivationOption;
+
+  before(() => {
+    // @ts-ignore
+    reactivationOption = getReactivationOptions(policy_active)[0];
+  });
+
+  // Quote hook
+  describe('Before reactivation', () => {
+    //   it('should return an error because the policy is already active', async () => {
+    //     var error = null;
+    //     try {
+    //       await beforePolicyReactivated({
+    //         // @ts-ignore
+    //         policy: policy_active,
+    //         reactivationOption: reactivationOption,
+    //       });
+    //     } catch (e) {
+    //       error = e;
+    //     }
+    //     expect(error).to.not.equal(null);
+    //   });
+
+    //   it('should return without error: lapsed policy', () => {
+    //     var error = null;
+    //     try {
+    //       beforePolicyReactivated({
+    //         // @ts-ignore
+    //         policy: policy_lapsed,
+    //         reactivationOption: reactivationOption,
+    //       });
+    //     } catch (e) {
+    //       error = e;
+    //     }
+    //     expect(error).to.equal(null);
+    //   });
+
+    //   it('should return without error: cancelled policy', () => {
+    //     var error = null;
+    //     try {
+    //       beforePolicyReactivated({
+    //         // @ts-ignore
+    //         policy: policy_cancelled,
+    //         reactivationOption: reactivationOption,
+    //       });
+    //     } catch (e) {
+    //       error = e;
+    //     }
+    //     expect(error).to.equal(null);
+    //   });
+
+    // A policy being reactivated with a status of cancelled and lapsed can be reactivated.
+    it('cancelled policy can be reactivated', () => {
+      var error = null;
+      try {
+        beforePolicyReactivated({
+          // @ts-ignore
+          policy: policy_cancelled || policy_lapsed,
+          reactivationOption: reactivationOption,
+        });
+      } catch (e) {
+        error = e;
+      }
+      expect(error).to.equal(null);
+    });
+
+    // A policy with a status of expired cannot be reactivated.
+    it('expired policy cannot be reactivated', () => {
+      var error = null;
+      try {
+        beforePolicyReactivated({
+          // @ts-ignore
+          policy: policy_expired,
+          reactivationOption: reactivationOption,
+        });
+      } catch (e) {
+        error = e;
+      }
+      expect(error).to.not.equal(null);
+    });
+  });
+});

--- a/code/unit-tests/04-lifecycle-hooks.tests.js
+++ b/code/unit-tests/04-lifecycle-hooks.tests.js
@@ -31,48 +31,6 @@ describe('Reactivation flow', () => {
 
   // Quote hook
   describe('Before reactivation', () => {
-    //   it('should return an error because the policy is already active', async () => {
-    //     var error = null;
-    //     try {
-    //       await beforePolicyReactivated({
-    //         // @ts-ignore
-    //         policy: policy_active,
-    //         reactivationOption: reactivationOption,
-    //       });
-    //     } catch (e) {
-    //       error = e;
-    //     }
-    //     expect(error).to.not.equal(null);
-    //   });
-
-    //   it('should return without error: lapsed policy', () => {
-    //     var error = null;
-    //     try {
-    //       beforePolicyReactivated({
-    //         // @ts-ignore
-    //         policy: policy_lapsed,
-    //         reactivationOption: reactivationOption,
-    //       });
-    //     } catch (e) {
-    //       error = e;
-    //     }
-    //     expect(error).to.equal(null);
-    //   });
-
-    //   it('should return without error: cancelled policy', () => {
-    //     var error = null;
-    //     try {
-    //       beforePolicyReactivated({
-    //         // @ts-ignore
-    //         policy: policy_cancelled,
-    //         reactivationOption: reactivationOption,
-    //       });
-    //     } catch (e) {
-    //       error = e;
-    //     }
-    //     expect(error).to.equal(null);
-    //   });
-
     // A policy being reactivated with a status of cancelled and lapsed can be reactivated.
     it('cancelled policy can be reactivated', () => {
       var error = null;


### PR DESCRIPTION
### Which part of the onboarding is this for?

- [ ] Part 1: Getting Set Up with Your First Product
- [ ] Part 2: Generating Insurance Quotes
- [ ] Part 3: Issuing Policies
- [ ] Part 4: Part 4: Amending Policies with Alteration Hooks
- [x] Part 5: Lifecycle Hooks and Reactivation
- [ ] Part 6: Scheduled Functions and Anniversary Logic
- [ ] Part 7: Crafting Documents and Documentation
- [ ] Part 8: Building a Claims and Payout Flow

### What has been implemented in this PR?
Root Product Builder Fundamentals Course Part 5: Lifecycle Hooks and Reactivation

### How was testing done?

**Types of tests required**

- [x] Unit test check (tests to be done prior to handing to reviewer)
- [x] API endpoint testing
- [x] Dashboard testing 

**Acceptance criteria**
- [x] If a policy is in a lapsed or cancelled state, it can be reactivated via the Root API or Dashboard.
- [x] Unit tests are written to see that a policy can be reactivated and the correct data is added to it. 

- [x] The policy has a reactivation date added to the module data on reactivation. 

- Unit tests for Reactivation flow
  - A policy being reactivated with a status of cancelled and lapsed can be reactivated. 
  - A policy with a status of expired cannot be reactivated.
 
**Link to a working quote, application, policy or claim - whichever is relevant to the part**
Screenshot of Policy
![CleanShot 2023-12-08 at 10 34 48](https://github.com/sajeezy/root-product-builder-fundamentals/assets/3699393/431d88f2-f70c-4164-955d-dcb4b8e9c319)

Screenshot of Cancelled policy
![CleanShot 2023-12-08 at 10 35 18](https://github.com/sajeezy/root-product-builder-fundamentals/assets/3699393/c35a49b4-3cc2-455b-b7b6-b406e939ebb1)

Screenshot of Reactivation Date
![CleanShot 2023-12-08 at 10 35 49](https://github.com/sajeezy/root-product-builder-fundamentals/assets/3699393/45affa37-ab57-4085-ba31-f39dcf7c1794)

Screenshot of Activity of Reactivation
![CleanShot 2023-12-08 at 10 35 58](https://github.com/sajeezy/root-product-builder-fundamentals/assets/3699393/afcb7fdf-d673-4d1f-8c1d-3d589de1d604)


Screenshot of Unit tests
![CleanShot 2023-12-08 at 09 04 37](https://github.com/sajeezy/root-product-builder-fundamentals/assets/3699393/02fcab72-abfd-482a-8ac4-1dbde64c7920)

### Authors considerations checklist

- [ ] Has unit tests been written to prove the PR is working?
- [ ] Is this PR being created into the correct branch (main or development)?

### Feedback and review

#### Were the specifications and Root guides clear enough?
- The guides gave me a great understanding of what to do considering there wasn't alot of data provided in the Onboarding doc so the guides came in handy.

#### What could have been explicated better to make this part easier to understand?
- I couldnt cancel my policy on the dashboard so I had to use the [cancel a policy API](https://docs.rootplatform.com/reference/cancel-policy-1)
- I used the API mostly for this section. Its not clear to me why policy actions on the dashboard are disabled. 
> Ignore above comment as it did end up working when I created a new policy, the dropdown actions worked (upon reflection this might be a platform constraint/enforcement)
- I thought (maybe still think), I needed to create an alteration for Reactivate but I saw 'Reactivate' action already so I'm confused about that. 
> On the above, I thought you could influence the modal because the reactivation date needed to be input by the user hence my train of thought


### Part Specific Questions
What other limits do you think would be useful to add to policy reactivation restrictions?
- Some business rules like reactivation can only happen in a 3 month or 6 month window
- A request for approval ie the reactivation rules can be defined by one user but they are not set by that same user. It could have some sort of account / audit controls to another person to approve.
